### PR TITLE
Move bind address to environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@
 
 FROM alpine:3.16.2
 
+ENV TFTPD_BIND_ADDRESS="0.0.0.0:1069"
 ENV TFTPD_EXTRA_ARGS=""
 
 # Package will be downloaded manually since armhf has no package for syslinux (#1).
@@ -42,4 +43,4 @@ CMD set -eu ;\
     # so use a boot directory with the special name "root" to have it's contents copied to the TFTP root directory.
     # See README for an example file structure for RPi.
     [ -d /tftpboot/boot/root ] && cp -af /tftpboot/boot/root/* /tftpboot ;\
-    exec in.tftpd -L -vvv -u ftp --secure --address 0.0.0.0:1069 $TFTPD_EXTRA_ARGS /tftpboot
+    exec in.tftpd -L -vvv -u ftp --secure --address "$TFTPD_BIND_ADDRESS" $TFTPD_EXTRA_ARGS /tftpboot

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     # image: registry.gitlab.com/kalaksi-containers/tftpd
     restart: unless-stopped
     environment:
+      # An interface and a port to listen to. "0.0.0.0" means all interfaces
+      TFTPD_BIND_ADDRESS: "0.0.0.0:1069"
       # Search the man page for --blocksize to learn more
       TFTPD_EXTRA_ARGS: '--blocksize 1468'
     cap_drop:


### PR DESCRIPTION
This is useful for example if container is running in a host or networked mode, so changing binded interface and port might be necessary